### PR TITLE
(PoC): lock series of locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## [Unreleased]
+## [1.16.0]
+### Added
+- Brand new Feature **"Lock series of locks"**
+  - (*Proof of Concpet*-based implementation at the moment) 
+  - lock series of lock simultainously (and release them all at the finish of your the invocation of block of code under the obtained locks);
+  - exmaple: `client.lock_series("a", "b", "c")` (or in exceptional-based way `client.lock_series!("a", "b", "c")`;
 ### Changed
 - YARDOC documentation updates in order to prearet to the 100% yardoc-coverage;
 - updated dev deps;

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redis_queued_locks (1.15.1)
+    redis_queued_locks (1.16.0)
       redis-client (~> 0.20)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -862,7 +862,8 @@ or (if block is not passed) while all locks will not expire.
 **IMPORTANT DETAILS AND LIMITATIONS**:
 - (this behavior will be reworked with another algorithm);
 - each lock will be released with the next formula: 
-  - `reverse-ordered lock position` * `ttl`
+  - `lock position with reverse numbering` * `ttl`
+    - (positions exmaple: ["a", "b", "c"] => "a" position is 3, "b" position is 2, "c" position is 1);
   - this means taht in case of 3 locks (`lock_series("x", "y", "z", ttl: 15_000`) with `5 seconds TTL` your locks will be with the next TTL:
     - `"x"` - 15 seconds
     - `"y"` - 10 seconds

--- a/lib/redis_queued_locks/acquirer.rb
+++ b/lib/redis_queued_locks/acquirer.rb
@@ -4,6 +4,7 @@
 # @since 1.0.0
 module RedisQueuedLocks::Acquirer
   require_relative 'acquirer/acquire_lock'
+  require_relative 'acquirer/lock_series_poc'
   require_relative 'acquirer/release_lock'
   require_relative 'acquirer/release_all_locks'
   require_relative 'acquirer/release_locks_of'

--- a/lib/redis_queued_locks/acquirer/acquire_lock.rb
+++ b/lib/redis_queued_locks/acquirer/acquire_lock.rb
@@ -155,7 +155,7 @@ module RedisQueuedLocks::Acquirer::AcquireLock
     # @yieldreturn [Any]
     # @return [Hash<Symbol,Any>,yield]
     #  - Format: { ok: true/false, result: Any }
-    #  - If block is given the result of block's yeld will be returned.
+    #  - If block is given the result of block's yield will be returned.
     #
     # @api private
     # @since 1.0.0

--- a/lib/redis_queued_locks/acquirer/acquire_lock/instr_visitor.rb
+++ b/lib/redis_queued_locks/acquirer/acquire_lock/instr_visitor.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 # @api private
-# @since 1.7.0
+# @since 1.16.0
+# rubocop:disable Metrics/ModuleLength
 module RedisQueuedLocks::Acquirer::AcquireLock::InstrVisitor
   class << self
     # @param instrumenter [#notify]
@@ -162,5 +163,27 @@ module RedisQueuedLocks::Acquirer::AcquireLock::InstrVisitor
         hold_time:, ttl:, acq_id:, hst_id:, ts:, lock_key:, acq_time:, instrument:
       }) rescue nil
     end
+
+    # NOTE: Lock Series PoC
+    # @api private
+    # @since 1.16.0
+    def lock_series_hold_and_release( # steep:ignore
+      instrumenter,
+      instr_sampled,
+      lock_keys,
+      ttl,
+      acq_id,
+      hst_id,
+      ts,
+      acq_time,
+      hold_time,
+      instrument
+    )
+      return unless instr_sampled
+      instrumenter.notify('redis_queued_locks.lock_series_hold_and_release', {
+        hold_time:, ttl:, acq_id:, hst_id:, ts:, lock_keys:, acq_time:, instrument:
+      }) # rescue nil
+    end
   end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/lib/redis_queued_locks/acquirer/acquire_lock/log_visitor.rb
+++ b/lib/redis_queued_locks/acquirer/acquire_lock/log_visitor.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # @api private
-# @since 1.7.0
+# @since 1.16.0
 # rubocop:disable Metrics/ModuleLength
 module RedisQueuedLocks::Acquirer::AcquireLock::LogVisitor
   # rubocop:disable Metrics/ClassLength
@@ -37,6 +37,30 @@ module RedisQueuedLocks::Acquirer::AcquireLock::LogVisitor
         "hst_id => '#{host_id}' " \
         "acs_strat => '#{access_strategy}'"
       end rescue nil
+    end
+
+    # NOTE: Lock Series PoC
+    # @api private
+    # @since 1.16.0
+    def start_lock_series_obtaining( # steep:ignore
+      logger,
+      log_sampled,
+      lock_keys,
+      queue_ttl,
+      acquirer_id,
+      host_id,
+      access_strategy
+    )
+      return unless log_sampled
+
+      logger.debug do
+        "[redis_queued_locks.start_lock_series_obtaining] " \
+        "lock_keys => '#{lock_keys.inspect}'" \
+        "queue_ttl => #{queue_ttl} " \
+        "acq_id => '#{acquirer_id}' " \
+        "hst_id => '#{host_id}' " \
+        "acs_strat => '#{access_strategy}'"
+      end # rescue nil
     end
 
     # @param logger [::Logger,#debug]
@@ -211,6 +235,32 @@ module RedisQueuedLocks::Acquirer::AcquireLock::LogVisitor
         "acs_strat => '#{access_strategy}' " \
         "acq_time => #{acq_time} (ms)"
       end rescue nil
+    end
+
+    # NOTE: Lock Series PoC
+    # @api private
+    # @since 1.16.0
+    def lock_series_obtained( # steep:ignore
+      logger,
+      log_sampled,
+      lock_keys,
+      queue_ttl,
+      acquirer_id,
+      host_id,
+      acq_time,
+      access_strategy
+    )
+      return unless log_sampled
+
+      logger.debug do
+        "[redis_queued_locks.lock_series_obtained] " \
+        "lock_keys => '#{lock_keys.inspect}' " \
+        "queue_ttl => #{queue_ttl} " \
+        "acq_id => '#{acquirer_id}' " \
+        "hst_id => '#{host_id}' " \
+        "acs_strat => '#{access_strategy}' " \
+        "acq_time => #{acq_time} (ms)"
+      end # rescue nil
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/lib/redis_queued_locks/acquirer/acquire_lock/yield_expire/log_visitor.rb
+++ b/lib/redis_queued_locks/acquirer/acquire_lock/yield_expire/log_visitor.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # @api private
-# @since 1.7.0
+# @since 1.16.0
 module RedisQueuedLocks::Acquirer::AcquireLock::YieldExpire::LogVisitor
   class << self
     # @param logger [::Logger,#debug]
@@ -30,6 +30,30 @@ module RedisQueuedLocks::Acquirer::AcquireLock::YieldExpire::LogVisitor
       logger.debug do
         "[redis_queued_locks.expire_lock] " \
         "lock_key => '#{lock_key}' " \
+        "queue_ttl => #{queue_ttl} " \
+        "acq_id => '#{acquirer_id}' " \
+        "hst_id => '#{host_id}' " \
+        "acs_strat => '#{access_strategy}'"
+      end rescue nil
+    end
+
+    # NOTE: Lock Series PoC
+    # @api private
+    # @since 1.16.0
+    def expire_lock_series( # steep:ignore
+      logger,
+      log_sampled,
+      lock_series,
+      queue_ttl,
+      acquirer_id,
+      host_id,
+      access_strategy
+    )
+      return unless log_sampled
+
+      logger.debug do
+        "[redis_queued_locks.expire_lock_series] " \
+        "lock_keys => '#{lock_series.inspect}' " \
         "queue_ttl => #{queue_ttl} " \
         "acq_id => '#{acquirer_id}' " \
         "hst_id => '#{host_id}' " \

--- a/lib/redis_queued_locks/acquirer/lock_series_poc.rb
+++ b/lib/redis_queued_locks/acquirer/lock_series_poc.rb
@@ -1,0 +1,303 @@
+# frozen_string_literal: true
+
+# NOTE: Lock Series PoC
+# steep:ignore
+# rubocop:disable all
+# @api private
+# @since 1.16.0
+module RedisQueuedLocks::Acquirer::LockSeriesPoC # steep:ignore
+  # @since 1.16.0
+  extend RedisQueuedLocks::Acquirer::AcquireLock::YieldExpire
+
+  class << self
+    # @api private
+    # @since 1.16.0
+    def lock_series_poc( # steep:ignore
+      redis,
+      lock_names,
+      detailed_result:,
+      process_id:,
+      thread_id:,
+      fiber_id:,
+      ractor_id:,
+      ttl:,
+      queue_ttl:,
+      timeout:,
+      timed:,
+      retry_count:,
+      retry_delay:,
+      retry_jitter:,
+      raise_errors:,
+      instrumenter:,
+      identity:,
+      fail_fast:,
+      meta:,
+      detailed_acq_timeout_error:,
+      instrument:,
+      logger:,
+      log_lock_try:,
+      conflict_strategy:,
+      read_write_mode:,
+      access_strategy:,
+      log_sampling_enabled:,
+      log_sampling_percent:,
+      log_sampler:,
+      log_sample_this:,
+      instr_sampling_enabled:,
+      instr_sampling_percent:,
+      instr_sampler:,
+      instr_sample_this:,
+      &block
+    )
+      case meta
+      when Hash, NilClass then nil
+      else
+        raise(
+          RedisQueuedLocks::ArgumentError,
+          "`:meta` argument should be a type of NilClass or Hash, got #{meta.class}."
+        )
+      end
+
+      if meta.is_a?(::Hash) && (meta.any? do |key, _value|
+        key == 'acq_id' ||
+        key == 'hst_id' ||
+        key == 'ts' ||
+        key == 'ini_ttl' ||
+        key == 'lock_key' ||
+        key == 'rem_ttl' ||
+        key == 'spc_ext_ttl' ||
+        key == 'spc_cnt' ||
+        key == 'l_spc_ext_ini_ttl' ||
+        key == 'l_spc_ext_ts' ||
+        key == 'l_spc_ts'
+      end)
+        raise(
+          RedisQueuedLocks::ArgumentError,
+          '`:meta` keys can not overlap reserved lock data keys ' \
+          '"acq_id", "hst_id", "ts", "ini_ttl", "lock_key", "rem_ttl", "spc_cnt", ' \
+          '"spc_ext_ttl", "l_spc_ext_ini_ttl", "l_spc_ext_ts", "l_spc_ts"'
+        )
+      end
+
+      locks_count = lock_names.size
+
+      lock_acquirement_operations = lock_names.each_with_index.map do |lock_name, position|
+        lock_ttl =
+          ttl * (locks_count - position) +
+          retry_delay * (locks_count - position) +
+          retry_jitter * (locks_count - position)
+
+        { lock_name: lock_name, ttl: lock_ttl }
+      end
+
+      log_sampled = RedisQueuedLocks::Logging.should_log?(
+        log_sampling_enabled,
+        log_sample_this,
+        log_sampling_percent,
+        log_sampler
+      )
+
+      instr_sampled = RedisQueuedLocks::Instrument.should_instrument?(
+        instr_sampling_enabled,
+        instr_sample_this,
+        instr_sampling_percent,
+        instr_sampler
+      )
+
+      lock_keys_for_instrumentation = lock_names.map do |lock_name|
+        RedisQueuedLocks::Resource.prepare_lock_key(lock_name)
+      end
+
+      acquirer_id_for_instrumentation = RedisQueuedLocks::Resource.acquirer_identifier(
+        process_id,
+        thread_id,
+        fiber_id,
+        ractor_id,
+        identity
+      )
+
+      host_id_for_instrumentation = RedisQueuedLocks::Resource.host_identifier(
+        process_id,
+        thread_id,
+        ractor_id,
+        identity
+      )
+
+      RedisQueuedLocks::Acquirer::AcquireLock::LogVisitor.start_lock_series_obtaining( # steep:ignore
+        logger, log_sampled, lock_keys_for_instrumentation,
+        queue_ttl, acquirer_id_for_instrumentation, host_id_for_instrumentation, access_strategy
+      )
+
+      acq_start_time = RedisQueuedLocks::Utilities.clock_gettime
+      successfully_acquired_locks = [] # steep:ignore
+      failed_locks_and_errors = {} # steep:ignore
+      failed_on_lock = nil
+
+      lock_acquirement_operations.map do |lock_operation_options|
+        result =
+          begin
+            RedisQueuedLocks::Acquirer::AcquireLock.acquire_lock(
+              redis,
+              lock_operation_options[:lock_name],
+              process_id:,
+              thread_id:,
+              fiber_id:,
+              ractor_id:,
+              ttl: lock_operation_options[:ttl],
+              queue_ttl:,
+              timeout:,
+              timed:,
+              retry_count:,
+              retry_delay:,
+              retry_jitter:,
+              raise_errors:,
+              instrumenter:,
+              identity:,
+              fail_fast:,
+              meta:,
+              detailed_acq_timeout_error:,
+              instrument:,
+              logger:,
+              log_lock_try:,
+              conflict_strategy:,
+              read_write_mode:,
+              access_strategy:,
+              log_sampling_enabled:,
+              log_sampling_percent:,
+              log_sampler:,
+              log_sample_this:,
+              instr_sampling_enabled:,
+              instr_sampling_percent:,
+              instr_sampler:,
+              instr_sample_this:
+            )
+          rescue => error
+            if raise_errors && successfully_acquired_locks.any?
+              # NOTE: release all previously acquired locks if any next lock is already locked
+              successfully_acquired_locks.each do |operation_result|
+                lock_key = RedisQueuedLocks::Resource.prepare_lock_key(operation_result[:lock_name])
+                redis.with do |conn|
+                  conn.multi(watch: [lock_key]) do |transact|
+                    transact.call('DEL', lock_key)
+                  end
+                end
+              end
+            end
+            raise(error)
+          end
+
+        if result[:ok]
+          successfully_acquired_locks << {
+            lock_name: lock_operation_options[:lock_name],
+            ok: result[:ok],
+            result: result[:result]
+          }
+        else
+          failed_on_lock = lock_operation_options[:lock_name]
+          failed_locks_and_errors[lock_operation_options[:lock_name]] = result
+          break
+        end
+      end
+
+      if (successfully_acquired_locks.size == lock_names.size && (successfully_acquired_locks.all? { |res| res[:ok] }))
+        acq_end_time = RedisQueuedLocks::Utilities.clock_gettime
+        acq_time = ((acq_end_time - acq_start_time) / 1_000.0).ceil(2)
+
+        RedisQueuedLocks::Acquirer::AcquireLock::LogVisitor.lock_series_obtained( # steep:ignore
+          logger, log_sampled, lock_keys_for_instrumentation,
+          queue_ttl, acquirer_id_for_instrumentation, host_id_for_instrumentation,
+          acq_time, access_strategy
+        )
+
+        yield_time = RedisQueuedLocks::Utilities.clock_gettime
+        ttl_shift = (
+          (yield_time - acq_end_time) / 1_000.0 -
+          RedisQueuedLocks::Resource::REDIS_TIMESHIFT_ERROR
+        ).ceil(2)
+
+        yield_result = yield_expire( # steep:ignore
+          redis,
+          logger,
+          lock_keys_for_instrumentation.last,
+          acquirer_id_for_instrumentation,
+          host_id_for_instrumentation,
+          access_strategy,
+          timed,
+          ttl_shift,
+          ttl,
+          queue_ttl,
+          meta,
+          log_sampled,
+          instr_sampled,
+          false, # should_expire (expire manually)
+          false, # should_decrease (expire manually)
+          &block
+        )
+
+        # expire locks manually
+        if block_given?
+          redis.with do |conn|
+            # use transaction in order to exclude any cross-locking during the group expiration
+            conn.multi(watch: lock_keys_for_instrumentation) do |transaction|
+              lock_keys_for_instrumentation.each do |lock_key|
+                transaction.call('EXPIRE', lock_key, '0')
+              end
+            end
+          end
+        end
+
+        rel_time = RedisQueuedLocks::Utilities.clock_gettime
+        hold_time = ((rel_time - acq_end_time) / 1_000.0).ceil(2)
+        ts = Time.now.to_f
+
+        RedisQueuedLocks::Acquirer::AcquireLock::YieldExpire::LogVisitor.expire_lock_series( # steep:ignore
+          logger, log_sampled, lock_keys_for_instrumentation,
+          queue_ttl, acquirer_id_for_instrumentation, host_id_for_instrumentation, access_strategy
+        )
+
+        RedisQueuedLocks::Acquirer::AcquireLock::InstrVisitor.lock_series_hold_and_release( # steep:ignore
+          instrumenter,
+          instr_sampled,
+          lock_keys_for_instrumentation,
+          ttl,
+          acquirer_id_for_instrumentation,
+          host_id_for_instrumentation,
+          ts,
+          acq_time,
+          hold_time,
+          instrument
+        )
+
+        if detailed_result
+          {
+            yield_result: yield_result,
+            locks_released_at: ts,
+            locks_acq_time: acq_time,
+            locks_hold_time: hold_time,
+            lock_series: lock_names,
+            rql_lock_series: lock_keys_for_instrumentation
+          }
+        else
+          yield_result
+        end
+      else
+        acquired_locks = successfully_acquired_locks.map { |state| state[:lock_name] }
+        missing_locks = lock_names - acquired_locks
+
+        {
+          ok: false,
+          result: {
+            error: :failed_to_acquire_lock_series,
+            detailed_errors: failed_locks_and_errors,
+            lock_series: lock_names,
+            acquired_locks:,
+            missing_locks:,
+            failed_on_lock:,
+          }
+        }
+      end
+    end
+  end
+end
+# steep:ignore
+# rubocop:enable all

--- a/lib/redis_queued_locks/client.rb
+++ b/lib/redis_queued_locks/client.rb
@@ -2,7 +2,7 @@
 
 # @api public
 # @since 1.0.0
-# @version 1.14.0
+# @version 1.16.0
 # rubocop:disable Metrics/ClassLength
 class RedisQueuedLocks::Client
   # @return [RedisClient]
@@ -305,7 +305,7 @@ class RedisQueuedLocks::Client
   #   @yieldreturn [Any]
   # @return [Hash<Symbol,Any>,yield]
   #   - Format: { ok: true/false, result: Symbol/Hash }.
-  #   - If block is given the result of block's yeld will be returned.
+  #   - If block is given the result of block's yield will be returned.
   #
   # @api public
   # @since 1.0.0
@@ -381,12 +381,156 @@ class RedisQueuedLocks::Client
   end
   # rubocop:enable Metrics/MethodLength
 
+  # NOTE: Lock Series PoC
+  # rubocop:disable all
+  # @api public
+  # @since 1.16.0
+  def lock_series( # steep:ignore
+    *lock_names,
+    detailed_result: false,
+    ttl: config['default_lock_ttl'], # steep:ignore
+    queue_ttl: config['default_queue_ttl'], # steep:ignore
+    timeout: config['try_to_lock_timeout'], # steep:ignore
+    timed: config['is_timed_by_default'], # steep:ignore
+    retry_count: config['retry_count'], # steep:ignore
+    retry_delay: config['retry_delay'], # steep:ignore
+    retry_jitter: config['retry_jitter'], # steep:ignore
+    raise_errors: false,
+    fail_fast: false,
+    conflict_strategy: config['default_conflict_strategy'], # steep:ignore
+    read_write_mode: :write,
+    access_strategy: config['default_access_strategy'], # steep:ignore
+    identity: uniq_identity,
+    meta: nil,
+    detailed_acq_timeout_error: config['detailed_acq_timeout_error'], # steep:ignore
+    logger: config['logger'], # steep:ignore
+    log_lock_try: config['log_lock_try'], # steep:ignore
+    instrumenter: config['instrumenter'], # steep:ignore
+    instrument: nil,
+    log_sampling_enabled: config['log_sampling_enabled'], # steep:ignore
+    log_sampling_percent: config['log_sampling_percent'], # steep:ignore
+    log_sampler: config['log_sampler'], # steep:ignore
+    log_sample_this: false,
+    instr_sampling_enabled: config['instr_sampling_enabled'], # steep:ignore
+    instr_sampling_percent: config['instr_sampling_percent'], # steep:ignore
+    instr_sampler: config['instr_sampler'], # steep:ignore
+    instr_sample_this: false,
+    &block
+  )
+    RedisQueuedLocks::Acquirer::LockSeriesPoC.lock_series_poc( # steep:ignore
+      redis_client,
+      lock_names,
+      detailed_result:,
+      process_id: RedisQueuedLocks::Resource.get_process_id,
+      thread_id: RedisQueuedLocks::Resource.get_thread_id,
+      fiber_id: RedisQueuedLocks::Resource.get_fiber_id,
+      ractor_id: RedisQueuedLocks::Resource.get_ractor_id,
+      ttl:,
+      queue_ttl:,
+      timeout:,
+      timed:,
+      retry_count:,
+      retry_delay:,
+      retry_jitter:,
+      raise_errors:,
+      instrumenter:,
+      identity:,
+      fail_fast:,
+      conflict_strategy:,
+      read_write_mode:,
+      access_strategy:,
+      meta:,
+      detailed_acq_timeout_error:,
+      logger:,
+      log_lock_try:,
+      instrument:,
+      log_sampling_enabled:,
+      log_sampling_percent:,
+      log_sampler:,
+      log_sample_this:,
+      instr_sampling_enabled:,
+      instr_sampling_percent:,
+      instr_sampler:,
+      instr_sample_this:,
+      &block
+    )
+  end
+  # rubocop:enable all
+
+  # NOTE: Lock Series PoC
+  # rubocop:disable all
+  # @api public
+  # @since 1.16.0
+  def lock_series!( # steep:ignore
+    *lock_names,
+    detailed_result: false,
+    ttl: config['default_lock_ttl'], # steep:ignore
+    queue_ttl: config['default_queue_ttl'], # steep:ignore
+    timeout: config['try_to_lock_timeout'], # steep:ignore
+    timed: config['is_timed_by_default'], # steep:ignore
+    retry_count: config['retry_count'], # steep:ignore
+    retry_delay: config['retry_delay'], # steep:ignore
+    retry_jitter: config['retry_jitter'], # steep:ignore
+    fail_fast: false,
+    conflict_strategy: config['default_conflict_strategy'], # steep:ignore
+    read_write_mode: :write,
+    access_strategy: config['default_access_strategy'], # steep:ignore
+    identity: uniq_identity,
+    meta: nil,
+    detailed_acq_timeout_error: config['detailed_acq_timeout_error'], # steep:ignore
+    logger: config['logger'], # steep:ignore
+    log_lock_try: config['log_lock_try'], # steep:ignore
+    instrumenter: config['instrumenter'], # steep:ignore
+    instrument: nil,
+    log_sampling_enabled: config['log_sampling_enabled'], # steep:ignore
+    log_sampling_percent: config['log_sampling_percent'], # steep:ignore
+    log_sampler: config['log_sampler'], # steep:ignore
+    log_sample_this: false,
+    instr_sampling_enabled: config['instr_sampling_enabled'], # steep:ignore
+    instr_sampling_percent: config['instr_sampling_percent'], # steep:ignore
+    instr_sampler: config['instr_sampler'], # steep:ignore
+    instr_sample_this: false,
+    &block
+  )
+    lock_series( # steep:ignore
+      *lock_names, # steep:ignore
+      detailed_result:,
+      ttl:,
+      queue_ttl:,
+      timeout:,
+      timed:,
+      retry_count:,
+      retry_delay:,
+      retry_jitter:,
+      raise_errors: true,
+      fail_fast:,
+      conflict_strategy:,
+      read_write_mode:,
+      access_strategy:,
+      identity:,
+      meta:,
+      detailed_acq_timeout_error:,
+      logger:,
+      log_lock_try:,
+      instrumenter:,
+      instrument:,
+      log_sampling_enabled:,
+      log_sampling_percent:,
+      log_sampler:,
+      log_sample_this:,
+      instr_sampling_enabled:,
+      instr_sampling_percent:,
+      instr_sampler:,
+      instr_sample_this:,
+      &block
+    )
+  end
+
   # @note See #lock method signature.
   #
   # @api public
   # @since 1.0.0
   # @version 1.13.0
-  # rubocop:disable Metrics/MethodLength
   def lock!(
     lock_name,
     ttl: config['default_lock_ttl'], # steep:ignore

--- a/lib/redis_queued_locks/swarm/swarm_element/isolated.rb
+++ b/lib/redis_queued_locks/swarm/swarm_element/isolated.rb
@@ -154,7 +154,7 @@ class RedisQueuedLocks::Swarm::SwarmElement::Isolated
   #
   # @api private
   # @since 1.9.0
-  # rubocop:disable Layout/ClassStructure, Lint/IneffectiveAccessModifier
+  # rubocop:disable Layout/ClassStructure, Lint/IneffectiveAccessModifier, Metrics/MethodLength
   def self.swarm_loop(&main_loop_spawner)
     # NOTE:
     #   This self.-related part of code is placed in the middle of class in order
@@ -177,7 +177,10 @@ class RedisQueuedLocks::Swarm::SwarmElement::Isolated
             # @type var main_loop: Thread
             RedisQueuedLocks::Utilities.thread_state(main_loop)
           end
-        Ractor.yield({ main_loop: { alive: main_loop_alive, state: main_loop_state } })
+        # NOTE: (will be reworked with Ractor::Port in the next RQL release (~1.17))
+        Ractor.yield({ # steep:ignore
+          main_loop: { alive: main_loop_alive, state: main_loop_state }
+        })
       when :is_active
         Ractor.yield(main_loop != nil && main_loop.alive?) # steep:ignore
       when :start
@@ -191,7 +194,7 @@ class RedisQueuedLocks::Swarm::SwarmElement::Isolated
       end
     end
   end
-  # rubocop:enable Layout/ClassStructure, Lint/IneffectiveAccessModifier
+  # rubocop:enable Layout/ClassStructure, Lint/IneffectiveAccessModifier, Metrics/MethodLength
 
   # @return [Boolean]
   #

--- a/lib/redis_queued_locks/version.rb
+++ b/lib/redis_queued_locks/version.rb
@@ -5,6 +5,6 @@ module RedisQueuedLocks
   #
   # @api public
   # @since 0.0.1
-  # @version 1.15.1
-  VERSION = '1.15.1'
+  # @version 1.16.0
+  VERSION = '1.16.0'
 end


### PR DESCRIPTION
`lock_serie` - acquire a series of locks _simultaionously_

Example:

```ruby
client.lock_series("a", "b", "c") { ...some_code... }
```

New instrumentation events (see new `README`  section of `lock_series` method documentation);
New logs (see readme section of `lock_series` method documentation);